### PR TITLE
Fix link in Slack setup article reference

### DIFF
--- a/vignettes/articles/slack.Rmd.orig
+++ b/vignettes/articles/slack.Rmd.orig
@@ -22,7 +22,7 @@ First make sure you are authorized to work with the Slack API:
 keys_check()
 ```
 
-If not, see the [Setting Up Slack](article/slack_app) article.
+If not, see the [Setting Up Slack](slack_app) article.
 
 Once you have set up your Slack access, you can use the Slack API to access
 the rOpenSci Slack space using httr2 directly or via the promoutils helper functions.


### PR DESCRIPTION
While working on #11, I found that the link to Slack Setup doesn't work because it adds an extra `article/`, making the full URL: https://docs.ropensci.org/promoutils/articles/article/slack_app (two'/article' segments). Then the resource is not there.

I made the change in the .orig file, but let me know if I should do it in the other one too.
